### PR TITLE
OPS-2201 helm values update to support IRSA in platform-nonprod-02

### DIFF
--- a/env/foxtel-platform-general-account-management-api-values.yaml
+++ b/env/foxtel-platform-general-account-management-api-values.yaml
@@ -5,8 +5,8 @@ foxtel-platform-general-account-management-api:
     NEW_RELIC_LICENSE_KEY: c3a6b94918f96d44af11c628b52630d59f5ad20c
     NEW_RELIC_AGENT_ENABLED: true
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED: true
-    spring.datasource.url: jdbc:oracle:thin:@sit1ws.sms.foxtel.com.au:1700/SIT1WS.SMS.FOXTEL.COM.AU
-    spring.datasource.username: ws
+    spring.datasource.url: jdbc:oracle:thin:@oracle-test.c7brt7o5khbq.ap-southeast-2.rds.amazonaws.com:1521/DEV0WS
+    spring.datasource.username: admin
   probePath: /actuator/health
   livenessProbe:
     initialDelaySeconds: 66
@@ -30,3 +30,8 @@ foxtel-platform-general-account-management-api:
     minReplicas: 1
     maxReplicas: 50
     targetCPUUtilizationPercentage: 35
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::841472843274:role/integration-account-mngmt-api-staging-iam-role
+    name: integration-account-mngmt-api-staging-iam-role

--- a/env/foxtel-platform-general-account-management-api-values.yaml
+++ b/env/foxtel-platform-general-account-management-api-values.yaml
@@ -5,8 +5,8 @@ foxtel-platform-general-account-management-api:
     NEW_RELIC_LICENSE_KEY: c3a6b94918f96d44af11c628b52630d59f5ad20c
     NEW_RELIC_AGENT_ENABLED: true
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED: true
-    spring.datasource.url: jdbc:oracle:thin:@oracle-test.c7brt7o5khbq.ap-southeast-2.rds.amazonaws.com:1521/DEV0WS
-    spring.datasource.username: admin
+    spring.datasource.url: jdbc:oracle:thin:@sit1ws.sms.foxtel.com.au:1700/SIT1WS.SMS.FOXTEL.COM.AU
+    spring.datasource.username: ws
   probePath: /actuator/health
   livenessProbe:
     initialDelaySeconds: 66

--- a/env/foxtel-platform-general-device-management-api-values.yaml
+++ b/env/foxtel-platform-general-device-management-api-values.yaml
@@ -33,3 +33,8 @@ foxtel-platform-general-device-management-api:
     minReplicas: 1
     maxReplicas: 50
     targetCPUUtilizationPercentage: 35
+  serviceAccount:
+    create: true
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::841472843274:role/integration-device-mngmt-api-staging-iam-role
+    name: integration-device-mngmt-api-staging-iam-role


### PR DESCRIPTION
This should help [fix](https://platform-nonprod-02-argocd.private.platform2.streamotion-platform-nonprod.com.au/applications/integration)

These two APIs use AWS resources (secrets) - add serviceaccount and annotations to enable this via [IRSA](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/)



reference: https://foxsportsau.atlassian.net/wiki/spaces/DEV/pages/1665237752/EKS+Upgrade+actions+1.15+-+1.19